### PR TITLE
fix 'none' fsDeviceKeyword mismatching as fsOptionsCache

### DIFF
--- a/syntax/fstab.vim
+++ b/syntax/fstab.vim
@@ -80,10 +80,10 @@ syn match fsOptionsKeywords contained /\<x-systemd\.\%(device-bound\|automount\|
 syn match fsOptionsKeywords contained /\<x-initrd\.mount/
 
 syn match fsOptionsKeywords contained /\<cache=/ nextgroup=fsOptionsCache
-syn keyword fsOptionsCache yes no none strict loose fscache mmap
+syn keyword fsOptionsCache contained yes no none strict loose fscache mmap
 
 syn match fsOptionsKeywords contained /\<dax=/ nextgroup=fsOptionsDax
-syn keyword fsOptionsDax inode never always
+syn keyword fsOptionsDax contained inode never always
 
 syn match fsOptionsKeywords contained /\<errors=/ nextgroup=fsOptionsErrors
 syn keyword fsOptionsErrors contained continue panic withdraw remount-ro recover zone-ro zone-offline repair


### PR DESCRIPTION
An fstab entry that starts with the 'none' device will incorrectly match the 'none' string as the `fsOptionsCache` keyword. It should be an `fsDeviceKeyword`, but the `fsOptionsCache` is missing the `contained` specifier so it can match anywhere.